### PR TITLE
v7.1.1 release - bump up Django minimum version requirement to v3.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,51 @@
 # Changelog
 
+## 7.1.1
+
+[Full Changelog](https://github.com/uktrade/directory-client-core/pull/31/files)
+
+- KLS-403 - Upgrade vulnerable django version to Django 3.2.18
+
 ## 7.1.0
+
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/28/files)
+
 - GLS-380 - Update maximum sigauth version for compatibility with Django 3.2
 
 ## 7.0.0
+
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/21/files)
+
 - GLS-392 - django version to update install requires django 3.2
 
 ## 6.3.0
+
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/24/files)
+
 - No ticket - bump django version in setup.py so Django 3.x can start using this package
 
 ## 6.2.0
+
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/23/files)
+
 - No ticket - Added missing data arg on delete method
 
 ## 6.0.1
+
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/20/files)
+
 - No ticket - django version to update install requires django 2.2
 
 ## 6.0.0
+
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/19/files)
+
 - No ticket - django version to django 2.2
 
 ## 5.1.1
+
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/14/files)
+
 ### Bug fixes
+
 - No ticket - Upgrade vulnerable django version to django 1.11.22

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_client_core',
-    version='7.1.0',
+    version='7.1.1',
     url='https://github.com/uktrade/directory-client-core',
     license='MIT',
     author='Department for International Trade',
@@ -18,8 +18,8 @@ setup(
         'requests>=2.21.0,<3.0.0',
         'monotonic>=1.2,<3.0',
         'sigauth>=4.0.1,<5.2.0',
-        'django>=1.11.22,<4.0.0',
-        'w3lib>=1.19.0<2.0.0',
+        'django>=3.2.18,<4.0.0',
+        'w3lib>=1.19.0,<2.0.0',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.

