### PR TITLE
Remove changelog check from PR template & codecov version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,7 @@ jobs:
             python3 -m venv .venv
             . .venv/bin/activate
             make test_requirements
-            make test
-            codecov
+            make test -- --codecov-token=${CODECOV_TOKEN}
 
   publish_to_pypi:
     docker:

--- a/makefile
+++ b/makefile
@@ -11,15 +11,19 @@ flake8:
 	flake8 . --exclude=.venv --max-line-length=120
 
 pytest:
-	pytest . --capture=no --cov=. --cov-config=.coveragerc $(pytest_args)
+	pytest . --capture=no
 
-CODECOV := \
-	if [ "$$CODECOV_REPO_TOKEN" != "" ]; then \
-	   codecov --token=$$CODECOV_REPO_TOKEN ;\
-	fi
+pytest_codecov:
+	pytest \
+		--junitxml=test-reports/junit.xml \
+		--cov-config=.coveragerc \
+		--cov-report=term \
+		--cov=. \
+		--codecov \
+		$(ARGUMENTS)
 
-test: flake8 pytest
-	$(CODECOV)
+
+test: flake8 pytest_codecov
 
 publish:
 	rm -rf build dist; \

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 To do (delete all that do not apply):
 
  - [ ] Change has a jira ticket that has the correct status.
- - [ ] Changelog entry added.
+ - [ ] A clear description/pull request message has been added.
  - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
  - [ ] (if updating requirements) Requirements have been compiled.
  - [ ] (if adding env vars) Added any new environment variable to vault.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_client_core',
-    version='7.1.1',
+    version='7.1.2',
     url='https://github.com/uktrade/directory-client-core',
     license='MIT',
     author='Department for International Trade',
@@ -23,13 +23,14 @@ setup(
     ],
     extras_require={
         'test': [
-            'codecov==2.1.9',
             'flake8==5.0.4',
             'freezegun==1.0.0',
-            'pytest-cov==2.10.1',
             'pytest-django==4.1.0',
             'pytest-sugar==0.9.5',
             'pytest==5.4.0',
+            'pytest-cov',
+            'pytest-codecov',
+            'GitPython',
             'requests_mock==1.8.0',
             'setuptools>=38.6.0,<39.0.0',
             'twine>=1.11.0,<2.0.0',


### PR DESCRIPTION
This PR updates the PR template to no longer mention the changelog as we are no longer mantaining it.

To be able to unblock the CI pipeline, this PR also includes an update to our codecov configuration to use pytest-codecov rather than the outdated codecov

 - [x] Change has a jira ticket that has the correct status.

