### PR TITLE
bump django to 4.2.3 (LTS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 7.2.4
 
-[Full Changelog]()
+[Full Changelog](https://github.com/uktrade/directory-client-core/pull/38)
 
 - KLS-822 - Upgrade django to 4.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## 7.2.4
+
+[Full Changelog]()
+
+- KLS-822 - Upgrade django to 4.2.3
+
 ## 7.2.3
 
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/37)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_client_core',
-    version='7.2.3',
+    version='7.2.4',
     url='https://github.com/uktrade/directory-client-core',
     license='MIT',
     author='Department for International Trade',
@@ -18,7 +18,7 @@ setup(
         'requests>=2.21.0,<3.0.0',
         'monotonic>=1.2,<3.0',
         'sigauth>=4.0.1,<=5.2.1',
-        'django>=3.2.18,<=4.2',
+        'django>=3.2.18,<=4.2.3',
         'w3lib>=1.19.0,<2.0.0',
     ],
     extras_require={


### PR DESCRIPTION
Bump django to 4.2.3 (required for great-magna-tests django upgrade)

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

