### PR TITLE
Upgrading Django to 4.2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_client_core',
-    version='7.2.6',
+    version='7.2.7',
     url='https://github.com/uktrade/directory-client-core',
     license='MIT',
     author='Department for International Trade',
@@ -18,7 +18,7 @@ setup(
         'requests>=2.21.0,<3.0.0',
         'monotonic>=1.2,<3.0',
         'sigauth>=4.0.1,<=5.2.2',
-        'django>=3.2.18,<=4.2.6',
+        'django>=3.2.18,<=4.2.7',
         'w3lib>=1.19.0,<2.0.0',
     ],
     extras_require={


### PR DESCRIPTION
Upgrading Django to 4.2.7 to resolve:

CVE-2023-46695
CVE-2023-43665
CVE-2023-41164

TSS-1390