### PR TITLE
Set Django Minimum to 4.2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,5 @@ Temporary Items
 # Docker
 .env
 
+venv
 .venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## 7.2.9
+
+[Full Changelog]() (23-01-2024)
+
+- KLS-1821 - Set Django Minimum 4.2.7
+
 ## 7.2.5
 
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 7.2.9
 
-[Full Changelog]() (23-01-2024)
+[Full Changelog](https://github.com/uktrade/directory-client-core/pull/43) (23-01-2024)
 
 - KLS-1821 - Set Django Minimum 4.2.7
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_client_core',
-    version='7.2.8',
+    version='7.2.9',
     url='https://github.com/uktrade/directory-client-core',
     license='MIT',
     author='Department for International Trade',
@@ -17,8 +17,8 @@ setup(
     install_requires=[
         'requests>=2.21.0,<3.0.0',
         'monotonic>=1.2,<3.0',
-        'sigauth>=4.0.1,<=5.2.3',
-        'django>=3.2.18,<=4.2.7',
+        'sigauth==5.2.4',
+        'django>=4.2.7,<4.2.8',
         'w3lib>=1.19.0,<2.0.0',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         'requests>=2.21.0,<3.0.0',
         'monotonic>=1.2,<3.0',
-        'sigauth==5.2.4',
+        'sigauth>=5.2.4,<6.0.0',
         'django>=4.2.7,<4.2.8',
         'w3lib>=1.19.0,<2.0.0',
     ],


### PR DESCRIPTION
Set Django Minimum to 4.2.7

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [x] (if updating requirements) Requirements have been compiled.
