### PR TITLE
Bump Django to 4.2.10 minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 7.2.12
 
-[Full Changelog]() (19-02-2024)
+[Full Changelog](https://github.com/uktrade/directory-client-core/pull/46) (19-02-2024)
 
 - KLS-1948 - Bump Django to 4.2.10 min
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## 7.2.12
+
+[Full Changelog]() (19-02-2024)
+
+- KLS-1948 - Bump Django to 4.2.10 min
+
 ## 7.2.11
 
 [Full Changelog](https://github.com/uktrade/directory-client-core/pull/45) (3-02-2024)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_client_core',
-    version='7.2.11',
+    version='7.2.12',
     url='https://github.com/uktrade/directory-client-core',
     license='MIT',
     author='Department for International Trade',
@@ -18,7 +18,7 @@ setup(
         'requests>=2.21.0,<3.0.0',
         'monotonic>=1.2,<3.0',
         'sigauth>=5.2.5,<6.0.0',
-        'django>=4.2.8,<5.0',
+        'django>=4.2.10,<5.0',
         'w3lib>=1.19.0,<2.0.0',
     ],
     extras_require={


### PR DESCRIPTION
To do (delete all that do not apply):

Bump Django to 4.2.10 minimum
KLS-1948 depends on this
